### PR TITLE
Update draft: Replace formatToParts() with getMessage(), document error handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,6 @@ for the creation of `MessageFormat` instances.
 The `ResolvedOptions` object contains the options
 resolved during the construction of the `MessageFormat` instance.
 
-The `msgPath` argument identifies the message from those available in the current resources.
-If all added resources share the same `id` value,
-the path may be given as a string or a string array.
-The `scope` argument is used to lookup variable references used in the `Message`.
-
 ```ts
 interface MessageFormatOptions {
   localeMatcher?: 'best fit' | 'lookup';
@@ -96,9 +91,17 @@ interface Intl.MessageFormat {
 
   addResources(...resources: Resource[]);
 
-  format(msgPath: MsgPath, scope?: Scope): string;
+  format(
+    msgPath: MsgPath,
+    scope?: Scope | null,
+    onError?: (error: Error) => void
+  ): string;
 
-  getMessage(msgPath: MsgPath, scope?: Scope): ResolvedMessage | undefined;
+  getMessage(
+    msgPath: MsgPath,
+    scope?: Scope | null,
+    onError?: (error: Error) => void
+  ): ResolvedMessage | undefined;
 
   resolvedOptions(): ResolvedOptions;
 }
@@ -107,6 +110,16 @@ interface Intl.MessageFormat {
 For formatting a message, two methods are provided: `format()` and `getMessage()`.
 The first of these will always return a simple string,
 while the latter returns a `ResolvedMessage` object or `undefined` if the message was not found.
+These methods have the following arguments:
+
+- `msgPath` identifies the message from those available in the current resources.
+  If all added resources share the same `id` value,
+  the path may be given as a string or a string array.
+- `scope` is used to lookup variable references used in the `Message`.
+- `onError` argument defines an error handler that will be called if
+  message resolution or formatting fails.
+  If `onError` is not defined,
+  errors will be ignored and a fallback representation used for the corresponding message part.
 
 `ResolvedMessage` is intended to provide a building block for the localization of messages
 in contexts where its representation as a plain string would not be sufficient.

--- a/README.md
+++ b/README.md
@@ -94,13 +94,13 @@ interface Intl.MessageFormat {
   format(
     msgPath: MsgPath,
     scope?: Scope | null,
-    onError?: (error: Error) => void
+    onError?: (error: Error, value: MessageValue) => void
   ): string;
 
   getMessage(
     msgPath: MsgPath,
     scope?: Scope | null,
-    onError?: (error: Error) => void
+    onError?: (error: Error, value: MessageValue) => void
   ): ResolvedMessage | undefined;
 
   resolvedOptions(): ResolvedOptions;

--- a/README.md
+++ b/README.md
@@ -69,15 +69,21 @@ The interfaces for
 will depend on the final MF2 data model.
 `MessageFormatOptions` contains configuration options
 for the creation of `MessageFormat` instances.
-The `Scope` object is used to lookup variable references used in the `Message`.
 The `ResolvedOptions` object contains the options
 resolved during the construction of the `MessageFormat` instance.
+
+The `msgPath` argument identifies the message from those available in the current resources.
+If all added resources share the same `id` value,
+the path may be given as a string or a string array.
+The `scope` argument is used to lookup variable references used in the `Message`.
 
 ```ts
 interface MessageFormatOptions {
   localeMatcher?: 'best fit' | 'lookup';
   ...
 }
+
+type MsgPath = string | string[] | { resId: string, path: string[] }
 
 type Scope = Record<string, unknown>
 
@@ -90,14 +96,9 @@ interface Intl.MessageFormat {
 
   addResources(...resources: Resource[]);
 
-  format(msgPath: string | string[], scope?: Scope): string;
-  format(resId: string, msgPath: string | string[], scope?: Scope): string;
+  format(msgPath: MsgPath, scope?: Scope): string;
 
-  formatToParts(
-    resId: string,
-    msgPath: string | string[],
-    scope?: Scope
-  ): MessageFormatPart[];
+  formatToParts(msgPath: MsgPath, scope?: Scope): MessageFormatPart[];
 
   resolvedOptions(): ResolvedOptions;
 }

--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ rather than relying upon userland libraries.
 The MF2 specification is still being developed by the working group.
 The API below is based upon one proposal under consideration,
 but should not be considered representative of a consensus among the working group.
-In particular, the API shape of
-`MessageFormatOptions`, `Message`, `Scope` and `ResolvedOptions`
+In particular, the API shapes of
+`MessageFormatOptions`, `Message`, and `ResolvedOptions`
 will depend upon the data model chosen by the working group.
 
 The interface provided by `Message` will be defined by
 the MF2 data model developed by the MF2 working group.
-It contains localized text for a particular locale.
+It contains a parsed representation of localized text for a particular locale.
 
 ```ts
 interface Message {}
@@ -54,7 +54,7 @@ but there are no constrains implied on the underlying implementation.
 
 ```ts
 interface Resource {
-  getId(): string;
+  id: string;
 
   getMessage(path: string[]): Message | undefined;
 }
@@ -65,8 +65,8 @@ The `Intl.MessageFormat` constructor creates `MessageFormat` instances for a giv
 The remaining operations are defined on `MessageFormat` instances.
 
 The interfaces for
-`MessageFormatOptions`, `Scope` and `ResolvedOptions`
-will be defined by the MF2 data model.
+`MessageFormatOptions` and `ResolvedOptions`
+will depend on the final MF2 data model.
 `MessageFormatOptions` contains configuration options
 for the creation of `MessageFormat` instances.
 The `Scope` object is used to lookup variable references used in the `Message`.
@@ -74,9 +74,12 @@ The `ResolvedOptions` object contains the options
 resolved during the construction of the `MessageFormat` instance.
 
 ```ts
-interface MessageFormatOptions { }
+interface MessageFormatOptions {
+  localeMatcher?: 'best fit' | 'lookup';
+  ...
+}
 
-interface Scope { }
+type Scope = Record<string, unknown>
 
 interface Intl.MessageFormat {
   new (


### PR DESCRIPTION
Closes #1 by simplifying the message path argument shape, with the intent of clarifying that the `resId` value is optional if shared between all added resources (ping @zbraniecki).

Adds & documents a `getMessage(): ResolvedMessage` method, as exploratory work with an implementation identified that the `formatToParts()` method it's replacing was insufficient for use as a base for e.g. DOM localisation. The `MessageValue` family of interfaces also brings in their use on the input side as partially formatted variables.

An initial draft of error handling via an `onError` callback is also added, and other minor changes to other interfaces are made.